### PR TITLE
#17: Fix Numeric Imprecision in Large Numbers Causing Optimizer Infinite Loop

### DIFF
--- a/src/app/components/hsoptimizer/hsoptimizer.service.js
+++ b/src/app/components/hsoptimizer/hsoptimizer.service.js
@@ -106,7 +106,11 @@ export default class HSOptimizer {
     // Okay this is a little bit magic... and approximate also, but it's fast !
     // TODO maybe switch to a more simple dichotomy
     let baseOffset = 0;
-    while (remainingHs >= 0 || baseLevelIncrease > 0) {
+    let lastBaseOffset = -1;
+    // Continue until we are no longer able to increase the level without spending more HS than we have,
+    // or until (for large numbers) the next iteration of level increases costs less HS than the available precision
+    while (baseOffset != lastBaseOffset && (remainingHs >= 0 || baseLevelIncrease > 0)) {
+      lastBaseOffset = baseOffset
       remainingHs = hsInStock;
       baseLevelIncrease = -1;
       while (remainingHs >= 0) {


### PR DESCRIPTION
**Summary**
- Add another exit condition in the optimizer which is to quit if an iteration completes without increasing the levels further.

**Details**
It's a pretty trivial fix, thanks to the algorithm already being fairly elegant.

My understanding is that the Optimizer will start increasing levels in powers of 2 until a further doubling would exceed the number of available HS. It then begins a new iteration, adding further precision to the level increase (increasing it by a smaller number each time). Finally, when a new iteration finds that it can't even increase by 1 more level without over-spending, it completes.

The bug here is that due to numeric imprecision, as we try to zero in on the number of levels to increase, getting more and more precise, there comes a time where we are increasing the levels by a small incremental amount (small power of 2), but not impacting the number of remaining hero souls, which results in an infinite loop, because the exit condition requires at least some HS to be 'spent' with the level increase.

This fix simply keeps track of the last base offset (level increase) calculated - if there has been no increase from one iteration to the next (because we could not not increase the base level by a number high enough to decrease the remaining hero souls without them going negative) then we can safely exit - because we have already found the most accurate level increase that numerical precision will allow.